### PR TITLE
Update .stderr files

### DIFF
--- a/tests/ui/has-arguments.stderr
+++ b/tests/ui/has-arguments.stderr
@@ -1,6 +1,6 @@
 error: this attribute takes no arguments
 
-  = help: use `#[contracts]`
+         = help: use `#[contracts]`
 
  --> $DIR/has-arguments.rs:3:1
   |

--- a/tests/ui/has-expr-argument.stderr
+++ b/tests/ui/has-expr-argument.stderr
@@ -1,6 +1,6 @@
 error: this attribute takes no arguments
 
-  = help: use `#[contracts]`
+         = help: use `#[contracts]`
 
  --> $DIR/has-expr-argument.rs:3:13
   |

--- a/tests/ui/item-is-not-a-function.stderr
+++ b/tests/ui/item-is-not-a-function.stderr
@@ -1,6 +1,6 @@
 error: item is not a function
 
-  = help: `#[contracts]` can only be used on functions
+         = help: `#[contracts]` can only be used on functions
 
  --> $DIR/item-is-not-a-function.rs:4:1
   |

--- a/tests/ui/precondition-is-not-an-expression.stderr
+++ b/tests/ui/precondition-is-not-an-expression.stderr
@@ -1,6 +1,6 @@
 error: expected an expression as argument
 
-  = help: example syntax: `#[precondition(argument % 2 == 0)]`
+         = help: example syntax: `#[precondition(argument % 2 == 0)]`
 
  --> $DIR/precondition-is-not-an-expression.rs:4:15
   |

--- a/tests/ui/zero-contracts.stderr
+++ b/tests/ui/zero-contracts.stderr
@@ -1,6 +1,6 @@
 error: no contracts were specified
 
-  = help: add a `#[precondition]`
+         = help: add a `#[precondition]`
 
  --> $DIR/zero-contracts.rs:3:1
   |


### PR DESCRIPTION
With compiler 1.60.0:

  $ rustc --version
  rustc 1.60.0 (7737e0b5c 2022-04-04)

The contents of teh `.stderr` files is slightly different so the `.stderr`
files needed updating using `TRYBUILD=overwrite cargo test`.

Without this change I was getting errors like the following, with the
change the tests pass.
```
  test tests/ui/has-arguments.rs ... mismatch

  EXPECTED:
  ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
  error: this attribute takes no arguments

    = help: use `#[contracts]`

   --> $DIR/has-arguments.rs:3:1
    |
  3 | #[contracts(a, b)]
    | ^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the attribute macro `contracts` (in Nightly builds, run with -Z macro-backtrace for more info)
  ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈

  ACTUAL OUTPUT:
  ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
  error: this attribute takes no arguments

           = help: use `#[contracts]`

   --> tests/ui/has-arguments.rs:3:1
    |
  3 | #[contracts(a, b)]
    | ^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the attribute macro `contracts` (in Nightly builds, run with -Z macro-backtrace for more info)
  ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
  note: If the actual output is the correct output you can bless it by rerunning
        your test with the environment variable TRYBUILD=overwrite

  test tests/ui/has-expr-argument.rs ... mismatch
```