### PR TITLE
fix: update rust-toolchain version; fix broken tests

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.55.0"
+channel = "1.63.0"
 profile = "minimal"

--- a/tests/ui/has-arguments.stderr
+++ b/tests/ui/has-arguments.stderr
@@ -1,6 +1,6 @@
 error: this attribute takes no arguments
 
-  = help: use `#[contracts]`
+         = help: use `#[contracts]`
 
  --> $DIR/has-arguments.rs:3:1
   |

--- a/tests/ui/has-expr-argument.stderr
+++ b/tests/ui/has-expr-argument.stderr
@@ -1,6 +1,6 @@
 error: this attribute takes no arguments
 
-  = help: use `#[contracts]`
+         = help: use `#[contracts]`
 
  --> $DIR/has-expr-argument.rs:3:13
   |

--- a/tests/ui/item-is-not-a-function.stderr
+++ b/tests/ui/item-is-not-a-function.stderr
@@ -1,6 +1,6 @@
 error: item is not a function
 
-  = help: `#[contracts]` can only be used on functions
+         = help: `#[contracts]` can only be used on functions
 
  --> $DIR/item-is-not-a-function.rs:4:1
   |

--- a/tests/ui/precondition-is-not-an-expression.stderr
+++ b/tests/ui/precondition-is-not-an-expression.stderr
@@ -1,6 +1,6 @@
 error: expected an expression as argument
 
-  = help: example syntax: `#[precondition(argument % 2 == 0)]`
+         = help: example syntax: `#[precondition(argument % 2 == 0)]`
 
  --> $DIR/precondition-is-not-an-expression.rs:4:15
   |

--- a/tests/ui/zero-contracts.stderr
+++ b/tests/ui/zero-contracts.stderr
@@ -1,6 +1,6 @@
 error: no contracts were specified
 
-  = help: add a `#[precondition]`
+         = help: add a `#[precondition]`
 
  --> $DIR/zero-contracts.rs:3:1
   |


### PR DESCRIPTION
- bring rust-toolchain to current stable - 1.63
- fix broken tests for .stderr files updates